### PR TITLE
Add support for multiple columns

### DIFF
--- a/lib/moving_window.rb
+++ b/lib/moving_window.rb
@@ -13,8 +13,8 @@ class MovingWindow
 
   def filter(scope, params = {})
     column, qualifier = parse(params)
-    t = scope.table_name
-    scope.where(["#{t}.#{column} #{qualifier} ? and ?", *timestamps])
+    query = columns_sql(scope.table_name, Array.wrap(column))
+    scope.where(["#{query} #{qualifier} ? and ?", *timestamps])
   end
 
   private
@@ -29,6 +29,11 @@ class MovingWindow
     from, to = @block.call
     to ||= Time.now
     [from, to].sort
+  end
+
+  def columns_sql(table_name, columns)
+    columns_string = columns.map { |name| "#{table_name}.#{name}" }.join(',')
+    columns.length > 1 ? "COALESCE(#{columns_string})" : columns_string
   end
 
   class Proc < ::Proc

--- a/moving_window.gemspec
+++ b/moving_window.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'moving_window'
-  s.version     = '2.0.4'
+  s.version     = '2.0.5'
   s.summary     = 'Moving Window'
   s.description = 'A helper for building scopes that deal with moving windows.'
   s.author      = 'Chris Patuzzo'
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.files       = ['README.md'] + Dir['lib/**/*.*']
 
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'activerecord'
+  s.add_development_dependency 'activerecord', '3.2.22'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
- We can pass array of columns to the scope method.
- There can be a case when we want to use one or multiple attributes for the moving window. If the primary one is blank, the other one will be used.